### PR TITLE
feat: include module before using context

### DIFF
--- a/local/modules/qwelp.site_location/components/city.context/class.php
+++ b/local/modules/qwelp.site_location/components/city.context/class.php
@@ -1,10 +1,16 @@
 <?php
+
+use Bitrix\Main\Loader;
 use Qwelp\SiteLocation\Context;
 
 class QwelpSiteLocationCityContextComponent extends CBitrixComponent
 {
     public function executeComponent()
     {
+        if (!Loader::includeModule('qwelp.site_location')) {
+            return;
+        }
+
         if ($this->StartResultCache()) {
             $this->arResult['CITY'] = Context::getCurrent();
             $this->IncludeComponentTemplate();

--- a/local/modules/qwelp.site_location/components/city.selector/class.php
+++ b/local/modules/qwelp.site_location/components/city.selector/class.php
@@ -18,7 +18,9 @@ class QwelpSiteLocationCitySelectorComponent extends CBitrixComponent implements
 
     public function executeComponent()
     {
-        if (!Loader::includeModule('iblock')) return;
+        if (!Loader::includeModule('qwelp.site_location') || !Loader::includeModule('iblock')) {
+            return;
+        }
         $this->arResult['IBLOCK_ID'] = (int)Option::get('qwelp.site_location', 'IBLOCK_ID', '0');
         if ($this->arResult['IBLOCK_ID'] <= 0) { $this->includeComponentTemplate(); return; }
 
@@ -43,6 +45,9 @@ class QwelpSiteLocationCitySelectorComponent extends CBitrixComponent implements
 
     public function selectAction(int $cityId)
     {
+        if (!Loader::includeModule('qwelp.site_location')) {
+            return ['status' => 'error'];
+        }
         Context::setCurrent($cityId);
         return ['status' => 'ok'];
     }

--- a/local/modules/qwelp.site_location/components/contacts.block/class.php
+++ b/local/modules/qwelp.site_location/components/contacts.block/class.php
@@ -1,10 +1,16 @@
 <?php
+
+use Bitrix\Main\Loader;
 use Qwelp\SiteLocation\Context;
 
 class QwelpSiteLocationContactsBlockComponent extends CBitrixComponent
 {
     public function executeComponent()
     {
+        if (!Loader::includeModule('qwelp.site_location')) {
+            return;
+        }
+
         if ($this->StartResultCache()) {
             $city = Context::getCurrent();
             $this->arResult['CITY'] = $city;


### PR DESCRIPTION
## Summary
- add qwelp.site_location module inclusion to city context component
- ensure city selector loads qwelp.site_location module before accessing context
- load module in contacts block component

## Testing
- `php -l local/modules/qwelp.site_location/components/city.context/class.php`
- `php -l local/modules/qwelp.site_location/components/city.selector/class.php`
- `php -l local/modules/qwelp.site_location/components/contacts.block/class.php`


------
https://chatgpt.com/codex/tasks/task_e_6899c8aec08c83268eef8fb8c5c41f0e