### PR TITLE
Fix autoload class registration for site location module

### DIFF
--- a/local/modules/qwelp.site_location/include.php
+++ b/local/modules/qwelp.site_location/include.php
@@ -1,6 +1,6 @@
 <?php
 use Bitrix\Main\Loader;
 Loader::registerAutoLoadClasses('qwelp.site_location', [
-    '\Qwelp\SiteLocation\Context' => 'lib/Context.php',
-    '\Qwelp\SiteLocation\EventHandlers' => 'lib/EventHandlers.php',
+    'Qwelp\SiteLocation\Context' => 'lib/Context.php',
+    'Qwelp\SiteLocation\EventHandlers' => 'lib/EventHandlers.php',
 ]);


### PR DESCRIPTION
## Summary
- fix class autoload registration for Qwelp site location module

## Testing
- `php -l local/modules/qwelp.site_location/include.php`
- `php -l local/modules/qwelp.site_location/lib/Context.php`


------
https://chatgpt.com/codex/tasks/task_e_6899cd9337448326937b5a1e74635a52